### PR TITLE
Migrate to ghcr.io Docker registry

### DIFF
--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -2,8 +2,8 @@
 
 set -eux
 
-docker pull docker.pkg.github.com/jonchang/fishtreeoflife-docker/data:latest
-docker run --name temp docker.pkg.github.com/jonchang/fishtreeoflife-docker/data:latest /bin/true
+docker pull ghcr.io/jonchang/fishtreeoflife-docker/data:latest
+docker run --name temp ghcr.io/jonchang/fishtreeoflife-docker/data:latest /bin/true
 docker cp temp:assets assets_tmp
 docker cp temp:_fossils _fossils
 docker cp temp:_data _data_tmp


### PR DESCRIPTION
I remember that you mentioned that you wanted to migrate the docker commands to the new container registry, which is ghcr.io. I tested it on my fresh Windows laptop (with the ghcr.io commands) and it worked just as expected. As for the Mac, the command works, even though I've previously used ./scripts/docker.sh