### PR TITLE
Pin specific commit of liquid-c

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 gem "jekyll", "4.3.1"
 gem "rake"
-gem "liquid-c"
+gem "liquid-c", github: "Shopify/liquid-c", ref: "a46872ed72dbf9246d9ac95bf2713fc26b01f9a9"
 gem "psych"
 
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/Shopify/liquid-c.git
+  revision: a46872ed72dbf9246d9ac95bf2713fc26b01f9a9
+  ref: a46872ed72dbf9246d9ac95bf2713fc26b01f9a9
+  specs:
+    liquid-c (4.0.0)
+      liquid (>= 3.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -74,8 +82,6 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    liquid-c (4.0.0)
-      liquid (>= 3.0.0)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -114,6 +120,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -124,7 +131,7 @@ DEPENDENCIES
   jekyll-seo-tag
   jekyll-sitemap
   jekyll-tidy
-  liquid-c
+  liquid-c!
   psych
   rake
 


### PR DESCRIPTION
This commit https://github.com/Shopify/liquid-c/commit/a46872ed72dbf9246d9ac95bf2713fc26b01f9a9 seems to not be included in 4.x and fixes some -Wall compiler warnings.